### PR TITLE
Add custom FileProvider to avoid collision in Manifest merger

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,7 +21,7 @@
 		</activity>
 
 		<provider
-			android:name="androidx.core.content.FileProvider"
+			android:name=".MyCustomFileProvider"
 			android:authorities="${applicationId}.fileprovider"
 			android:exported="false"
 			android:grantUriPermissions="true"

--- a/app/src/main/java/com/example/malauzaigliasampleapp/MyCustomFileProvider.kt
+++ b/app/src/main/java/com/example/malauzaigliasampleapp/MyCustomFileProvider.kt
@@ -1,0 +1,10 @@
+package com.example.malauzaigliasampleapp
+
+import androidx.core.content.FileProvider
+
+/**
+ * As our library and Your application both use the same FileProvider so it collides in a manifest merger,
+ * to avoid this You need to define an empty class extending File provider and use its provider name in Manifest.
+ */
+class MyCustomFileProvider : FileProvider() {
+}


### PR DESCRIPTION
Currently, this solution will solve your problem, but we will implement this on our side to avoid further conflicts in the manifest.